### PR TITLE
Wait until the data is written before closing the temporary partition file.

### DIFF
--- a/lib.coffee
+++ b/lib.coffee
@@ -99,8 +99,9 @@ exports.injectToFAT32 = (path, destination, data) ->
 			if data instanceof Stream
 				data.pipe(tmpStream)
 			else
-				tmpStream.write(data)
-				tmpStream.close()
+				tmpStream.writeAsync(data)
+				.then ->
+					tmpStream.closeAsync()
 		.then ->
 			cp.execAsync("mcopy -o -i #{path} -s #{tmpPath} ::#{destination}")
 		.spread (stdout, stderr) ->

--- a/lib.js
+++ b/lib.js
@@ -102,8 +102,9 @@
         if (data instanceof Stream) {
           return data.pipe(tmpStream);
         } else {
-          tmpStream.write(data);
-          return tmpStream.close();
+          return tmpStream.writeAsync(data).then(function() {
+            return tmpStream.closeAsync();
+          });
         }
       }).then(function() {
         return cp.execAsync("mcopy -o -i " + path + " -s " + tmpPath + " ::" + destination);


### PR DESCRIPTION
In rare cases `tmpStream` was closed before the data was written.
See https://github.com/resin-io/resin-image-maker/issues/59

Change-Type: patch